### PR TITLE
using LTS-12.5

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,9 @@ extra-package-dbs: []
 packages:
 - '.'
 extra-deps:
-- snap-1.0.0.2
-- heist-1.0.1.2
-- map-syntax-0.2.0.2
-resolver: lts-7.24
+- snap-1.1.1.0
+- heist-1.1
+- map-syntax-0.3
+- xmlhtml-0.2.5.2
+- pwstore-fast-2.4.4
+resolver: lts-12.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,9 +3,7 @@ extra-package-dbs: []
 packages:
 - '.'
 extra-deps:
-- aeson-0.11.2.0
-- base-orphans-0.5.4
-- cpphs-1.20.1
-- fail-4.9.0.0
-- text-1.2.2.0
-resolver: lts-5.2
+- snap-1.0.0.2
+- heist-1.0.1.2
+- map-syntax-0.2.0.2
+resolver: lts-7.24


### PR DESCRIPTION
This PR allows you to build QuickPlot with LTS-12.5 (GHC-8.4.3)

I suggest that specify max major version numbers of each package in cabal file, but I don't do that in this PR.